### PR TITLE
Fixed bugs in AmazonPollyUserControl and  

### DIFF
--- a/TextToSpeech/Controls/Options/AmazonPollyUserControl.cs
+++ b/TextToSpeech/Controls/Options/AmazonPollyUserControl.cs
@@ -91,7 +91,8 @@ namespace JocysCom.TextToSpeech.Monitor.Controls.Options
 		private void SpeakButton_Click(object sender, EventArgs e)
 		{
 			StatusTextBox.Text = "";
-			var text = MessageTextBox.Text;
+			var promptBuilder = new System.Speech.Synthesis.PromptBuilder();
+			promptBuilder.AppendText(MessageTextBox.Text);
 			var client = new Voices.AmazonPolly(
 				SettingsManager.Options.AmazonAccessKey,
 				SettingsManager.Options.AmazonSecretKey,
@@ -101,7 +102,7 @@ namespace JocysCom.TextToSpeech.Monitor.Controls.Options
 			Amazon.Polly.Engine engine = null;
 			if (voice.SupportedEngines.Contains(Amazon.Polly.Engine.Neural))
 				engine = Amazon.Polly.Engine.Neural;
-			var buffer = client.SynthesizeSpeech(voice.Id, text, null, engine);
+			var buffer = client.SynthesizeSpeech(voice.Id, promptBuilder.ToXml(), null, engine);
 			var result = client.LastException == null ? "Success" : client.LastException.Message;
 			StatusTextBox.Text = string.Format("{0:HH:mm:ss}: {1}", DateTime.Now, result);
 			var item = Global.DecodeToPlayItem(buffer);

--- a/TextToSpeech/Controls/Options/AmazonPollyUserControl.cs
+++ b/TextToSpeech/Controls/Options/AmazonPollyUserControl.cs
@@ -35,6 +35,7 @@ namespace JocysCom.TextToSpeech.Monitor.Controls.Options
 			if (region != null)
 				RegionComboBox.SelectedItem = region;
 			RegionComboBox.SelectedIndexChanged += RegionComboBox_SelectedIndexChanged;
+			RegionComboBox_SelectedIndexChanged(null, null);
 			//AmazonEnabledCheckBox.DataBindings.Add(nameof(AmazonEnabledCheckBox.Checked), SettingsManager.Options, nameof(SettingsManager.Options.AmazonEnabled));
 		}
 


### PR DESCRIPTION
While setting up Amazon Polly, I encountered two bugs. 

The first being that there was an exception when initially clicking "Speak" due to a voice not being set as default. 
![image](https://user-images.githubusercontent.com/19418761/100532982-31f8bc80-31f7-11eb-83b6-1233086412a1.png)

I solved this by invoking the `RegionComboBox_SelectedIndexChanged` event, however this may not be the ideal way to achieve the goal of fixing this bug. Please suggest any edits you feel necessary. 

The second bug was due to the request being expected as SSML, and `AmazonPollyUserControl.MessageTextBox.Text` not being formatted as such. Using `PromptBuilder` solves this issue in a way that will work for all use cases. There is the potential to use string concatenation/interpolation, however I am not sure how special characters would be encoded. 